### PR TITLE
[bugfix] Handle a non-empty path

### DIFF
--- a/XInTheLoop/Resources/tools/site1-protocol.py
+++ b/XInTheLoop/Resources/tools/site1-protocol.py
@@ -48,7 +48,8 @@ MAGIC = (0x53434656, 0x73636676)  # Little endian (b'VFCS', b'vfcs')
 VER = (3, 3)
 TYPES = ((int,) + 3*(float,), 3*(int,) + 22*(float,))
 
-fname = Path('_' + argv[0])
+fname = Path(argv[0])
+fname = fname.parent / ('_' + fname.name)
 
 def savefile(direction : int, send_or_receive : int) -> Path:
   """Return Path object storing the last package."""


### PR DESCRIPTION
Fixes #7

- Avoid exception when executing site1-protocol.py with a non-empty path.
- Make sure adding prefix to the filename only, not the path.